### PR TITLE
clarify invoices table header name

### DIFF
--- a/components/InvoiceFinancing/InvoicesTable.tsx
+++ b/components/InvoiceFinancing/InvoicesTable.tsx
@@ -69,7 +69,7 @@ function InvoicesTable({
                   <div className="font-semibold text-left">Issued on</div>
                 </th>
                 <th className="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-                  <div className="font-semibold text-left">Paid on</div>
+                  <div className="font-semibold text-left">Due on</div>
                 </th>
                 {showFinanceColumn && (
                   <th className="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">


### PR DESCRIPTION
changed invoices table header name "PAID ON" to "DUE ON" which is more intuitive for platform customers