### PR TITLE
Pin pnpm to 10.30.3 to match KanmonOS and unblock Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "demo-platform",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@11.0.4",
+  "packageManager": "pnpm@10.30.3",
   "scripts": {
     "dev": "next dev -p 4202",
     "build": "next build",
@@ -72,5 +72,10 @@
     "prettier": "^3.3.3",
     "tailwindcss": "^3.4.1",
     "typescript": "5.4.5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "unrs-resolver"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1586,8 +1586,8 @@ packages:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
 
-  is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
   is-data-view@1.0.2:
@@ -3787,7 +3787,7 @@ snapshots:
   eslint-import-resolver-node@0.3.10:
     dependencies:
       debug: 3.2.7
-      is-core-module: 2.16.1
+      is-core-module: 2.16.2
       resolve: 2.0.0-next.6
     transitivePeerDependencies:
       - supports-color
@@ -3830,7 +3830,7 @@ snapshots:
       eslint-import-resolver-node: 0.3.10
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1)
       hasown: 2.0.3
-      is-core-module: 2.16.1
+      is-core-module: 2.16.2
       is-glob: 4.0.3
       minimatch: 3.1.5
       object.fromentries: 2.0.8
@@ -4244,7 +4244,7 @@ snapshots:
 
   is-callable@1.2.7: {}
 
-  is-core-module@2.16.1:
+  is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.3
 
@@ -4851,14 +4851,14 @@ snapshots:
   resolve@1.22.12:
     dependencies:
       es-errors: 1.3.0
-      is-core-module: 2.16.1
+      is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
   resolve@2.0.0-next.6:
     dependencies:
       es-errors: 1.3.0
-      is-core-module: 2.16.1
+      is-core-module: 2.16.2
       node-exports-info: 1.6.0
       object-keys: 1.1.1
       path-parse: 1.0.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-allowBuilds:
-  unrs-resolver: true


### PR DESCRIPTION
## Summary
The merged pnpm 11 setup (#83) broke Vercel deployment. Vercel uses pnpm 9 by default and treats `pnpm-workspace.yaml` as a workspace marker, erroring on the missing `packages:` field.

This PR:
- Pins `packageManager` to `pnpm@10.30.3` to match KanmonOS
- Replaces `pnpm-workspace.yaml#allowBuilds` with `package.json#pnpm.onlyBuiltDependencies` (the pnpm 10 way), which pnpm 9 ignores cleanly
- Regenerates `pnpm-lock.yaml` with pnpm 10.30.3 (still v9 format, so Vercel's pnpm 9 can install it)

## Test plan
- [ ] Vercel preview deploy succeeds
- [ ] CI workflow passes (typecheck, lint, prettier)
- [ ] Local: `pnpm install && pnpm typecheck && pnpm lint && pnpm build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)